### PR TITLE
Firefox doesn't parse dates in the format "YYYY-MM-DD HH:MM:SS +HHMM"…

### DIFF
--- a/test.html
+++ b/test.html
@@ -21,12 +21,12 @@
 		for (ii = 0; ii < 15; ii++) {
 
 			data.push({
-				x: Date.parse("2015-04-27 04:00:00 +0300") + ii * 24 * 3600000,
+				x: Date.parse("2015-04-27T04:00:00+03:00") + ii * 24 * 3600000,
 				y: getRandomInt(0, 100)
 			});
 
 			data2.push({
-				x: Date.parse("2015-04-27 04:00:00 +0300") + ii * 24 * 3600000,
+				x: Date.parse("2015-04-27T04:00:00+03:00") + ii * 24 * 3600000,
 				y: getRandomInt(0, 100)
 			});
 		}
@@ -55,7 +55,7 @@
 
 		setInterval(function () {
 
-			var arg = Date.parse("2015-04-27 04:00:00 +0300") + ii * 24 * 3600000;
+			var arg = Date.parse("2015-04-27T04:00:00+03:00") + ii * 24 * 3600000;
 
 			myChart.datasets[0].removePoint(0);
 			myChart.datasets[1].removePoint(0);


### PR DESCRIPTION
…, it requires the usage of ISO 8601 date formats, e.g. "YYYY-MM-DDTHH:MM:SS+HH:MM".

Because of this, the test plot from test.html would throw a "RangeException" in Firefox while attempting to render the graph.

This commit changes the test dates to standard ISO 8601 format dates.
