### PR TITLE
Compatibility layer for Chart.js

### DIFF
--- a/Chart.Scatter.js
+++ b/Chart.Scatter.js
@@ -688,6 +688,10 @@
 			this.datasets = [];
 			this.scale = this._initScale();
 
+			// Compatibility layer
+			if (datasets.datasets) {
+				datasets = datasets.datasets;
+			}
 
 			//Iterate through each of the datasets, and build this into a property of the chart
 			helpers.each(datasets, function (dataset) {


### PR DESCRIPTION
It appears that Chart.js sends graph initialisation parameter with an object that contains `datasets` instead of sending datasets directly.

This adds the compatibility layer that supports this.
