### PR TITLE
added point radius support (aka bubble chart)

### DIFF
--- a/Chart.Scatter.js
+++ b/Chart.Scatter.js
@@ -616,20 +616,20 @@
 			this.points = [];
 		};
 
-		datasetCtr.prototype.addPoint = function (x, y) {
+		datasetCtr.prototype.addPoint = function (x, y, r) {
 
 			var point = this._createNewPoint();
-			this._setPointData(point, x, y);
+			this._setPointData(point, x, y, r);
 			this.points.push(point);
 		};
 
-		datasetCtr.prototype.setPointData = function (index, x, y) {
+		datasetCtr.prototype.setPointData = function (index, x, y, r) {
 
 			var point = hlp.getElementOrDefault(this.points, index);
 
 			if (point) {
 
-				this._setPointData(point, x, y);
+				this._setPointData(point, x, y, r);
 			}
 		};
 
@@ -641,7 +641,7 @@
 			}
 		};
 
-		datasetCtr.prototype._createNewPoint = function (x, y) {
+		datasetCtr.prototype._createNewPoint = function (x, y, r) {
 
 			return new chartjs.Point({
 
@@ -650,7 +650,7 @@
 
 				// point
 				display: this.pointDot,
-				radius: this.pointDotRadius,
+				radius: +r * this.pointDotRadius,
 				hitDetectionRadius: this.pointHitDetectionRadius,
 				strokeWidth: this.pointDotStrokeWidth,
 
@@ -662,7 +662,7 @@
 			});
 		};
 
-		datasetCtr.prototype._setPointData = function (point, x, y) {
+		datasetCtr.prototype._setPointData = function (point, x, y, r) {
 
 			var formattedArg = this.scale.argToString(+x),
 				formattedValue = +y + "";
@@ -670,7 +670,10 @@
 			point.arg = +x;
 			point.value = +y;
 
-			point.argLabel = helpers.template(this.scaleArgLabel, { value: formattedArg }),
+      point.size = +r;  // for use in templates
+      point.radius = +r * this.pointDotRadius;
+
+      point.argLabel = helpers.template(this.scaleArgLabel, { value: formattedArg }),
 			point.valueLabel = helpers.template(this.scaleLabel, { value: formattedValue });
 		};
 
@@ -704,7 +707,7 @@
 
 				helpers.each(dataset.data, function (dataPoint) {
 
-					datasetObject.addPoint(dataPoint.x, dataPoint.y);
+					datasetObject.addPoint(dataPoint.x, dataPoint.y, dataPoint.r || 1);
 				});
 
 			}, this);

--- a/index.html
+++ b/index.html
@@ -267,11 +267,11 @@ pointHitDetectionRadius: <strong>4</strong>,
 <strong>// TEMPLATES</strong>
 
 // Interpolated JS string - can access point fields: 
-// argLabel, valueLabel, arg, value, datasetLabel
+// argLabel, valueLabel, arg, value, datasetLabel, size
 tooltipTemplate: <strong>"<%if (datasetLabel){%><%=datasetLabel%>: <%}%><%=argLabel%>; <%=valueLabel%>"</strong>
 
 // Interpolated JS string - can access point fields: 
-// argLabel, valueLabel, arg, value, datasetLabel
+// argLabel, valueLabel, arg, value, datasetLabel, size
 multiTooltipTemplate: <strong>"<%=argLabel%>; <%=valueLabel%>",</strong>
 
 // Interpolated JS string - can access all chart fields
@@ -292,7 +292,7 @@ var data = [
         { x: 19, y: 65 }, 
         { x: 27, y: 59 }, 
         { x: 28, y: 69 }, 
-        { x: 40, y: 81 },
+        { x: 40, y: 81, r:3 },
         { x: 48, y: 56 }
       ]
     },
@@ -306,7 +306,7 @@ var data = [
         { x: 27, y: 69 }, 
         { x: 28, y: 70 }, 
         { x: 40, y: 31 },
-        { x: 48, y: 76 }, 
+        { x: 48, y: 76, r:3},
         { x: 52, y: 23 }, 
         { x: 24, y: 32 }
       ]
@@ -327,6 +327,13 @@ myChart.datasets[0].setPointData(3, 11, 4);
 
 <strong>// Remove the point at index 0</strong>
 myChart.datasets[0].removePoint(0);
+</pre>
+<p>
+  A point can also have a radius specified by <code>r</code>.  It is drawn as a multiple of <code>pointDotRadius</code>.  The default radius is 1.
+</p>
+<pre>
+<strong>// Add a new point (with radius) { x: 5, y: 7, r:2 }</strong>
+myChart.datasets[0].addPoint(5, 7, 2);
 </pre>
 				<p>
 					After all changes call the <code>update</code> method of the chart for render your chart with new data.
@@ -482,8 +489,8 @@ myChart.update();
 					label: 'complex-1',
 					strokeColor: '#F16220',
 					data: [
-						{ x: 19, y: 65 }, { x: 27, y: 59 }, { x: 28, y: 69 }, { x: 40, y: 81 },
-						{ x: 48, y: 56 }, { x: 86, y: 55 }, { x: 90, y: 40 }, { x: 95, y: 60 }
+						{ x: 19, y: 65 }, { x: 27, y: 59 }, { x: 28, y: 69 }, { x: 40, y: 81, r:3 },
+						{ x: 48, y: 56 }, { x: 86, y: 55 }, { x: 90, y: 40, r:2 }, { x: 95, y: 60 }
 					]
 				},
 				{
@@ -491,7 +498,7 @@ myChart.update();
 					strokeColor: '#007ACC',
 					data: [
 						{ x: 19, y: 75 }, { x: 27, y: 69 }, { x: 28, y: 70 }, { x: 40, y: 31 },
-						{ x: 48, y: 76 }, { x: 52, y: 23 }, { x: 24, y: 32 },
+						{ x: 48, y: 76, r:3 }, { x: 52, y: 23, r:2 }, { x: 24, y: 32 },
 						{ x: 86, y: 45 }, { x: 90, y: 50 }
 					]
 				}


### PR DESCRIPTION
an (x,y,r) point allows the scatter plot to also work as a [bubble chart](http://www.highcharts.com/demo/bubble).

eg, created with this patch:

![bubble](https://cloud.githubusercontent.com/assets/233047/8420910/e6d2fb00-1e7c-11e5-84cd-feccfc040eaa.jpg)
