### PR TITLE
Fixing Y-label formatation

### DIFF
--- a/Chart.Scatter.js
+++ b/Chart.Scatter.js
@@ -285,12 +285,14 @@
 
 			generateLabels: function (templateString, numberOfSteps, graphMin, stepValue) {
 
-				var labelsArray = new Array(numberOfSteps + 1);
+				var labelsArray = new Array(numberOfSteps + 1),
+						stepDecimalPlaces = helpers.getDecimalPlaces(this.stepValue);
+
 				if (templateString) {
 
 					helpers.each(labelsArray, function (val, index) {
 
-						labelsArray[index] = helpers.template(templateString, { value: (graphMin + (stepValue * (index))) });
+						labelsArray[index] = helpers.template(templateString, { value: (graphMin + (stepValue * (index))).toFixed(stepDecimalPlaces) });
 
 					});
 				}

--- a/Chart.Scatter.js
+++ b/Chart.Scatter.js
@@ -286,7 +286,7 @@
 			generateLabels: function (templateString, numberOfSteps, graphMin, stepValue) {
 
 				var labelsArray = new Array(numberOfSteps + 1),
-						stepDecimalPlaces = helpers.getDecimalPlaces(this.stepValue);
+						stepDecimalPlaces = helpers.getDecimalPlaces(stepValue);
 
 				if (templateString) {
 


### PR DESCRIPTION
# Before

![bildschirmfoto 2015-07-28 um 15 01 14](https://cloud.githubusercontent.com/assets/1645253/8931971/693579fa-353a-11e5-80e2-ff266e2ca7f9.png)
# After

![bildschirmfoto 2015-07-28 um 15 00 06](https://cloud.githubusercontent.com/assets/1645253/8931973/6bde0a8c-353a-11e5-9bb7-7e5d0e5c0a07.png)

The fix is from https://github.com/nnnick/Chart.js/blob/master/src/Chart.Core.js#L1556 and will round the Y-labels with the length of the step value.
