### PR TITLE
Chart module alias for browserify.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
 	"bugs": {
 		"url": "https://github.com/dima117/Chart.Scatter/issues"
 	},
-	"homepage": "http://dima117.github.io/Chart.Scatter"
+	"homepage": "http://dima117.github.io/Chart.Scatter",
+	"browser": {
+		"Chart": "chart.js"
+	},
 }


### PR DESCRIPTION
npm module is named "chart.js" as listed in "dependencies". With this alias it is possible to use browserify without any external plugins/transforms. See [Chart.Scatter.js:9](https://github.com/dima117/Chart.Scatter/blob/master/Chart.Scatter.js#L9)
